### PR TITLE
X11 path

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -96,5 +96,3 @@
 
 2004-05-04 AIDA Shinra <shinra@j10n.org>
 * Initial revision. Automated update of system xinitrc is not yet done.
-
-$Id: ChangeLog,v 1.8 2008/02/27 14:09:59 aida_s Exp $

--- a/build.sh
+++ b/build.sh
@@ -85,8 +85,8 @@ dobuild() {
 	*)
     $run cat > "$builddir/build.sed" << EOF
 s|@PREFIX@|$prefix|g
-s|@XINITDIR@|/usr/X11R6/lib/X11/xinit|g
-s|@X_BINDIR@|/usr/X11R6/bin|g
+s|@XINITDIR@|/opt/X11/lib/X11/xinit|g
+s|@X_BINDIR@|/opt/X11/bin|g
 EOF
 	;;
     esac

--- a/build.sh
+++ b/build.sh
@@ -80,12 +80,20 @@ go_p() {
 dobuild() {
     go $mkinstalldirscmd "$builddir"
     $show "creating build.sed"
+    if [[ -d /opt/X11/etc/X11/xinit ]]; then
+        xinitdir = /opt/X11/etc/X11/xinit;
+    elif [[ -d /opt/X11/lib/X11/xinit ]]; then
+        xinitdir = /opt/X11/lib/X11/xinit;
+    else
+    	echo "xinit dir for X11 not found. Exiting."
+    	exit 1;
+    fi
     case "x$run" in
 	x:) ;;
 	*)
     $run cat > "$builddir/build.sed" << EOF
 s|@PREFIX@|$prefix|g
-s|@XINITDIR@|/opt/X11/etc/X11/xinit|g
+s|@XINITDIR@|/$xinitdir|g
 s|@X_BINDIR@|/opt/X11/bin|g
 EOF
 	;;

--- a/build.sh
+++ b/build.sh
@@ -85,7 +85,7 @@ dobuild() {
 	*)
     $run cat > "$builddir/build.sed" << EOF
 s|@PREFIX@|$prefix|g
-s|@XINITDIR@|/opt/X11/lib/X11/xinit|g
+s|@XINITDIR@|/opt/X11/etc/X11/xinit|g
 s|@X_BINDIR@|/opt/X11/bin|g
 EOF
 	;;

--- a/build.sh
+++ b/build.sh
@@ -92,7 +92,7 @@ dobuild() {
 	*)
     $run cat > "$builddir/build.sed" << EOF
 s|@PREFIX@|$prefix|g
-s|@XINITDIR@|/$xinitdir|g
+s|@XINITDIR@|$xinitdir|g
 s|@X_BINDIR@|/opt/X11/bin|g
 EOF
 	;;

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,4 @@
 #! /bin/sh
-# $Id: build.sh,v 1.2 2005/04/08 20:44:32 aida_s Exp $
 # vim: set sw=4:
 set -e
 

--- a/build.sh
+++ b/build.sh
@@ -99,7 +99,7 @@ EOF
     esac
     for src in "$srcdir"/sedsrc/*.in; do
 	base=`basename "$src" .in`
-	go_r "$builddir/$base" sed -f "$builddir/build.sed" "$src"
+	go_r "$builddir/$base" /usr/bin/sed -f "$builddir/build.sed" "$src"
     done
 }
 
@@ -177,12 +177,12 @@ dofink() {
 	;;
     esac
 
-    go_r "$pkgname.info" sed $sedargs "$srcdir/$pkgname.info.in"
+    go_r "$pkgname.info" /usr/bin/sed $sedargs "$srcdir/$pkgname.info.in"
 }
 
 myname=`basename "$0"`
 case "x$myfullname" in
-    x*/*) mydir=`echo "$myfullname" | sed 's|/[^/]*$||'` ;;
+    x*/*) mydir=`echo "$myfullname" | /usr/bin/sed 's|/[^/]*$||'` ;;
     *) mydir=. ;;
 esac
 pkgname="xinitrc"

--- a/build.sh
+++ b/build.sh
@@ -80,9 +80,9 @@ dobuild() {
     go $mkinstalldirscmd "$builddir"
     $show "creating build.sed"
     if [[ -d /opt/X11/etc/X11/xinit ]]; then
-        xinitdir = /opt/X11/etc/X11/xinit;
+        xinitdir="/opt/X11/etc/X11/xinit";
     elif [[ -d /opt/X11/lib/X11/xinit ]]; then
-        xinitdir = /opt/X11/lib/X11/xinit;
+        xinitdir="/opt/X11/lib/X11/xinit";
     else
     	echo "xinit dir for X11 not found. Exiting."
     	exit 1;

--- a/doc/numbering.txt
+++ b/doc/numbering.txt
@@ -1,5 +1,3 @@
-$Id: numbering.txt,v 1.1 2005/04/07 12:31:26 aida_s Exp $
-
 This document describes a proposed numbering policy.
 If you found some problems, mail to:
 fink@sodan.ecc.u-tokyo.ac.jp

--- a/sedsrc/sys-xinitrc-fink.in
+++ b/sedsrc/sys-xinitrc-fink.in
@@ -8,55 +8,55 @@ if test -r "@PREFIX@/etc/xinitrc-override"; then
 elif test -r "@PREFIX@/bin/xinitrc.sh"; then
     . "@PREFIX@/bin/xinitrc.sh"
 else
-    # Xterm and a window manager may be used for trouble shooting.
-    # Run these programs carefully.
+	# Xterm and a window manager may be used for trouble shooting.
+	# Run these programs carefully.
 
-    userresources=$HOME/.Xresources
-    usermodmap=$HOME/.Xmodmap
-    sysresources=@XINITDIR@/.Xresources
-    sysmodmap=@XINITDIR@/.Xmodmap
-    x_bindir=@X_BINDIR@
+	userresources=$HOME/.Xresources
+	usermodmap=$HOME/.Xmodmap
+	sysresources=@XINITDIR@/.Xresources
+	sysmodmap=@XINITDIR@/.Xmodmap
+	x_bindir=@X_BINDIR@
 
-    # merge in defaults and keymaps
+	# merge in defaults and keymaps
 
-    if test -f $sysresources; then
-	xrdb -merge $sysresources
-    fi
+	if test -f $sysresources; then
+		xrdb -merge $sysresources
+	fi
 
-    if test -f $sysmodmap; then
-	xmodmap $sysmodmap
-    fi
+	if test -f $sysmodmap; then
+		xmodmap $sysmodmap
+	fi
 
-    if test -f $userresources; then
-	xrdb -merge $userresources
-    fi
+	if test -f $userresources; then
+		xrdb -merge $userresources
+	fi
 
-    if test -f $usermodmap; then
-	xmodmap $usermodmap
-    fi
+	if test -f $usermodmap; then
+		xmodmap $usermodmap
+	fi
 
-    # start some nice programs
+	# start some nice programs
 
-# Panther or Tiger only. On Leopard, use app_to_run in org.x.X11.plist instead.
-case "`/usr/bin/uname -r`" in
-7*|8*)
-    if test -x "$x_bindir/xterm"; then
-	termcmd="$x_bindir/xterm"
-    else
-	termcmd="xterm"
-    fi
-    $termcmd &
-    ;;
-esac
+	# Panther or Tiger only. On Leopard, use app_to_run in org.x.X11.plist instead.
+	case "`/usr/bin/uname -r`" in
+	7*|8*)
+		if test -x "$x_bindir/xterm"; then
+			termcmd="$x_bindir/xterm"
+		else
+			termcmd="xterm"
+		fi
+		$termcmd &
+		;;
+	esac
 
     # start the window manager
 
-    if type quartz-wm >/dev/null 2>&1; then
-	sessionmgr="`which quartz-wm`"
-    elif test -x "$x_bindir/twm"; then
-	sessionmgr="$x_bindir/twm"
-    else
-	sessionmgr="twm"
-    fi
+	if type quartz-wm >/dev/null 2>&1; then
+		sessionmgr="`which quartz-wm`"
+	elif test -x "$x_bindir/twm"; then
+		sessionmgr="$x_bindir/twm"
+	else
+		sessionmgr="twm"
+	fi
     exec $sessionmgr
 fi

--- a/sedsrc/sys-xinitrc-fink.in
+++ b/sedsrc/sys-xinitrc-fink.in
@@ -1,6 +1,4 @@
 #! /bin/sh
-# $Id: sys-xinitrc-fink.in,v 1.5 2008/02/18 06:41:09 okayama Exp $
-
 # This script works even after the Fink "xinitrc" package is removed.
 # Don't worry.
 

--- a/sedsrc/update-sys-xinitrc.in
+++ b/sedsrc/update-sys-xinitrc.in
@@ -2,7 +2,15 @@
 # $Id: update-sys-xinitrc.in,v 1.3 2008/02/27 14:10:00 aida_s Exp $
 set -e
 fink_prefix="@PREFIX@"
-sysxinitdir="/opt/X11/etc/X11/xinit"
+# This works whichever X is in use
+if [[ -d /opt/X11/etc/X11/xinit ]]; then
+	sysxinitdir="/opt/X11/etc/X11/xinit";
+elif [[ -d /opt/X11/lib/X11/xinit ]]; then
+	sysxinitdir="/opt/X11/lib/X11/xinit";
+else
+	echo "xinit dir for X11 not found. Exiting."
+	exit 1;
+fi
 target="$sysxinitdir/xinitrc"
 master="$fink_prefix/share/xinitrc/sys-xinitrc-fink"
 myname="update-sys-xinitrc"

--- a/sedsrc/update-sys-xinitrc.in
+++ b/sedsrc/update-sys-xinitrc.in
@@ -1,5 +1,4 @@
 #! /bin/sh
-# $Id: update-sys-xinitrc.in,v 1.3 2008/02/27 14:10:00 aida_s Exp $
 set -e
 fink_prefix="@PREFIX@"
 # This works whichever X is in use

--- a/sedsrc/update-sys-xinitrc.in
+++ b/sedsrc/update-sys-xinitrc.in
@@ -2,7 +2,7 @@
 # $Id: update-sys-xinitrc.in,v 1.3 2008/02/27 14:10:00 aida_s Exp $
 set -e
 fink_prefix="@PREFIX@"
-sysxinitdir="/opt/X11/lib/X11/xinit"
+sysxinitdir="/opt/X11/etc/X11/xinit"
 target="$sysxinitdir/xinitrc"
 master="$fink_prefix/share/xinitrc/sys-xinitrc-fink"
 myname="update-sys-xinitrc"

--- a/sedsrc/update-sys-xinitrc.in
+++ b/sedsrc/update-sys-xinitrc.in
@@ -2,7 +2,7 @@
 # $Id: update-sys-xinitrc.in,v 1.3 2008/02/27 14:10:00 aida_s Exp $
 set -e
 fink_prefix="@PREFIX@"
-sysxinitdir="/usr/X11R6/lib/X11/xinit"
+sysxinitdir="/opt/X11/lib/X11/xinit"
 target="$sysxinitdir/xinitrc"
 master="$fink_prefix/share/xinitrc/sys-xinitrc-fink"
 myname="update-sys-xinitrc"

--- a/sedsrc/update-sys-xinitrc.in
+++ b/sedsrc/update-sys-xinitrc.in
@@ -15,38 +15,38 @@ master="$fink_prefix/share/xinitrc/sys-xinitrc-fink"
 myname="update-sys-xinitrc"
 
 if test -t 0; then
-    isatty=true
+	isatty=true
 else
-    isatty=false
+	isatty=false
 fi
 
 if test "x`id -u`" != x0; then
-    echo "You must be root to run $myname."
-    exit 1
+	echo "You must be root to run $myname."
+	exit 1
 fi
 
 if test ! -f "$master"; then
-  echo "The file $master is missing."
-  echo "$myname can not continue without this file."
-  exit 1
+	echo "The file $master is missing."
+	echo "$myname can not continue without this file."
+	exit 1
 fi
 
 if test ! -d "$sysxinitdir"; then
-  echo "The directory $sysxinitdir is missing."
-  echo "$myname can not continue without this file."
-  exit 1
+	echo "The directory $sysxinitdir is missing."
+	echo "$myname can not continue without this file."
+	exit 1
 fi
 
 echo
 if cmp -s "$master" "$target"; then
-    echo "No need to update system xinitrc."
-    exit 0
+	echo "No need to update system xinitrc."
+	exit 0
 fi
 
 trap 'echo Aborting.' 0
 case "x$1" in
-    xpostinst)
-    cat << EOF
+	xpostinst)
+	cat << EOF
 Fink X11 startup framework needs to replace following file:
 $target
 to a copy of following file:
@@ -60,15 +60,15 @@ $fink_prefix/etc/xinitrc-override
 
 If you don't know what all of this is about, just say yes.
 EOF
-    ;;
-    *)
-    cat << EOF
+	;;
+	*)
+	cat << EOF
 Replacing following file:
 $target
 to a copy of following file:
 $master
 EOF
-    ;;
+	;;
 esac
 
 echo "If the system-wide xinitrc alredy exists, a backup is made. Don't worry."
@@ -76,19 +76,19 @@ echo
 /bin/echo -n "Do you want to continue? [Y/n] "
 read answer || :
 case "x$answer" in
-    x[Yy]*|x)
-    if test -f "$target"; then
+	x[Yy]*|x)
+	if test -f "$target"; then
 	datestr=`date "+%Y%m%d%H%M"` 
 	echo "Making backup of xinitrc (saved as xinitrc.$datestr) ..."
 	/bin/cp "$target" "$target.$datestr"
-    else
+	else
 	echo "System-wide xinitrc does not exist. No need to backup."
-    fi
-    echo "Installing new xinitrc ..."
-    /usr/bin/install -m 444 "$master" "$target"
-    ;;
-    *)
-    echo "Okay, not installing new xinitrc."
+	fi
+	echo "Installing new xinitrc ..."
+	/usr/bin/install -m 444 "$master" "$target"
+	;;
+	*)
+	echo "Okay, not installing new xinitrc."
 esac
 trap '' 0
 exit 0

--- a/sedsrc/xinitrc.sh.in
+++ b/sedsrc/xinitrc.sh.in
@@ -11,7 +11,7 @@ fink_sysconfdir="$fink_prefix/etc"
 x_prefix="/opt/X11"
 x_bindir="$x_prefix/bin"
 # This works whichever X is in use
-x_xinitdir="$x_prefix/lib/X11/xinit"
+x_xinitdir="$x_prefix/etc/X11/xinit"
 
 # Hook for system administrators.
 if test -f "$fink_sysconfdir/xinitrc-first-hook"; then

--- a/sedsrc/xinitrc.sh.in
+++ b/sedsrc/xinitrc.sh.in
@@ -8,7 +8,7 @@
 fink_prefix="@PREFIX@"
 fink_bindir="$fink_prefix/bin"
 fink_sysconfdir="$fink_prefix/etc"
-x_prefix="/usr/X11R6"
+x_prefix="/opt/X11"
 x_bindir="$x_prefix/bin"
 # This works whichever X is in use
 x_xinitdir="$x_prefix/lib/X11/xinit"

--- a/sedsrc/xinitrc.sh.in
+++ b/sedsrc/xinitrc.sh.in
@@ -21,7 +21,7 @@ fi
 
 # Hook for system administrators.
 if test -f "$fink_sysconfdir/xinitrc-first-hook"; then
-    . "$fink_sysconfdir/xinitrc-first-hook"
+	. "$fink_sysconfdir/xinitrc-first-hook"
 fi
 
 # Customization variables.
@@ -31,32 +31,32 @@ fi
 : ${xinitrc_sessionmgr_runmethod="exec"}
 
 case "x$xinitrc_fink_init_sh_enable" in
-    x[Yy][Ee][Ss]) . "$xinitrc_fink_init_sh_path" ;;
+	x[Yy][Ee][Ss]) . "$xinitrc_fink_init_sh_path" ;;
 esac
 
 # Numbering policy is described in $fink_prefix/share/doc/xinitrc/numbering.txt.
 if test -d "$xinitrc_xinitrc_d_dir"; then
-    for xinitrc__f in $xinitrc_xinitrc_d_dir/*.sh; do
+	for xinitrc__f in $xinitrc_xinitrc_d_dir/*.sh; do
 	if test -r "$xinitrc__f" -a -x "$xinitrc__f"; then
-	    . "$xinitrc__f"
+		. "$xinitrc__f"
 	fi
-    done
-    unset xinitrc__f
+	done
+	unset xinitrc__f
 fi
 
 # Hook for system administrators.
 if test -f "$fink_sysconfdir/xinitrc-last-hook"; then
-    . "$fink_sysconfdir/xinitrc-last-hook"
+	. "$fink_sysconfdir/xinitrc-last-hook"
 fi
 
 # Start the session or window manager
 if test x"$xinitrc_sessionmgr" != x; then
-    :
+	:
 elif type quartz-wm >/dev/null 2>&1; then
-    xinitrc_sessionmgr="`which quartz-wm`"
+	xinitrc_sessionmgr="`which quartz-wm`"
 elif test -x "$x_bindir/twm"; then
-    xinitrc_sessionmgr="$x_bindir/twm"
+	xinitrc_sessionmgr="$x_bindir/twm"
 else
-    xinitrc_sessionmgr="twm"
+	xinitrc_sessionmgr="twm"
 fi
 $xinitrc_sessionmgr_runmethod $xinitrc_sessionmgr

--- a/sedsrc/xinitrc.sh.in
+++ b/sedsrc/xinitrc.sh.in
@@ -11,7 +11,14 @@ fink_sysconfdir="$fink_prefix/etc"
 x_prefix="/opt/X11"
 x_bindir="$x_prefix/bin"
 # This works whichever X is in use
-x_xinitdir="$x_prefix/etc/X11/xinit"
+if [[ -d $x_prefix/etc/X11/xinit ]]; then
+	x_xinitdir="$x_prefix/etc/X11/xinit";
+elif [[ -d $x_prefix/lib/X11/xinit ]]; then
+	x_xinitdir="$x_prefix/lib/X11/xinit";
+else
+	echo "xinit dir for X11 not found. Exiting."
+	exit 1;
+fi
 
 # Hook for system administrators.
 if test -f "$fink_sysconfdir/xinitrc-first-hook"; then

--- a/sedsrc/xinitrc.sh.in
+++ b/sedsrc/xinitrc.sh.in
@@ -1,5 +1,4 @@
 #! /bin/sh
-# $Id: xinitrc.sh.in,v 1.3 2008/02/16 02:28:30 okayama Exp $
 # vim: set sw=4 sts=4 ts=8 noexpandtab:
 
 # Both direct execution and ". $fink_bindir/xinitrc.sh" are supported.

--- a/simple/20dispconf.sh
+++ b/simple/20dispconf.sh
@@ -1,4 +1,3 @@
-# $Id: 20dispconf.sh,v 1.2 2008/02/27 14:10:00 aida_s Exp $
 : ${xinitrc_dispconf_xrdb_enable=YES}
 : ${xinitrc_dispconf_sysresources="$x_xinitdir/.Xresources"}
 : ${xinitrc_dispconf_userresources="$HOME/.Xresources"}

--- a/simple/73apps.sh
+++ b/simple/73apps.sh
@@ -1,4 +1,3 @@
-# $Id: 73apps.sh,v 1.4 2008/02/16 12:30:58 okayama Exp $
 case "`/usr/bin/uname -r`" in
     7*|8*) : ${xinitrc_apps_term_enable=YES} ;;
     9*)    : ${xinitrc_apps_term_enable=NO}  ;;

--- a/xinitrc.info.in
+++ b/xinitrc.info.in
@@ -1,4 +1,3 @@
-# $Id: xinitrc.info.in,v 1.2 2008/02/16 12:30:56 okayama Exp $
 Package: xinitrc
 Version: @FULLVERSION@
 # Revision is always 1


### PR DESCRIPTION
* Apply current PatchScript perl-pie into the code.
* Change code to use /opt/X11/etc/X11/xinit that was implemented with Xquartz 2.8.

Because the lib -> etc change is a direct replacement, we would stop supporting Xquartz < 2.8 (unless the older Xquartz are also installing the `etc/X11/xinit` directory but just not using it).